### PR TITLE
IsDisposed as public property

### DIFF
--- a/EvtSource/EventSourceReader.cs
+++ b/EvtSource/EventSourceReader.cs
@@ -19,7 +19,12 @@ namespace EvtSource
         private Stream Stream = null;
         private Uri Uri;
 
-        private volatile bool IsDisposed = false;
+        private volatile bool _IsDisposed = false;
+        public bool IsDisposed
+        {
+            get { return _IsDisposed; }
+        }
+
         private volatile bool IsReading = false;
         private object StartLock = new object();
 
@@ -43,7 +48,7 @@ namespace EvtSource
         /// <exception cref="ObjectDisposedException">Dispose() has been called</exception>
         public EventSourceReader Start()
         {
-            if (IsDisposed)
+            if (_IsDisposed)
             {
                 throw new ObjectDisposedException("EventSourceReader");
             }
@@ -67,7 +72,7 @@ namespace EvtSource
         /// </summary>
         public void Dispose()
         {
-            IsDisposed = true;
+            _IsDisposed = true;
             Stream?.Dispose();
             Hc.CancelPendingRequests();
             Hc.Dispose();


### PR DESCRIPTION
When disposing a EventSourceReader instance, the `Disconnected` event is invoked and you can't reference that instance. It may be useful to discriminate between disposed and not disposed instances with a public property `IsDisposed`.