### PR TITLE
Fix infinitly growing of header Last-Event-Id

### DIFF
--- a/EvtSource/EventSourceReader.cs
+++ b/EvtSource/EventSourceReader.cs
@@ -85,6 +85,11 @@ namespace EvtSource
             {
                 if (string.Empty != LastEventId)
                 {
+                    if (Hc.DefaultRequestHeaders.Contains("Last-Event-Id"))
+                    {
+                        Hc.DefaultRequestHeaders.Remove("Last-Event-Id");
+                    }
+                    
                     Hc.DefaultRequestHeaders.TryAddWithoutValidation("Last-Event-Id", LastEventId);
                 }
                 using (HttpResponseMessage response = await Hc.GetAsync(Uri, HttpCompletionOption.ResponseHeadersRead))


### PR DESCRIPTION
On every reconnect the value of the Last-Event-Id grows until the request header is to long for the server.
